### PR TITLE
Various fixes/changes based on issues uncovered initially in El Capitan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ logs/*
 bin/onboot/*
 !bin/onboot/.keep
 bin/.tmp
+.version

--- a/bin/macosa
+++ b/bin/macosa
@@ -153,7 +153,8 @@ fi
 
 # Run the playbook
 printf "Running main playbook against local connection...\n"
-ansible-playbook -i inventory/all $passthru macos.yml
+become_pass=$(cat .vaultpass)
+ansible-playbook -i inventory/all --extra-vars="ansible_become_pass=$become_pass" $passthru macos.yml
 
 if [ -f user/reminders/after ]; then
   printf "There are some reminders for you after this run:\n"

--- a/bin/macosa
+++ b/bin/macosa
@@ -66,8 +66,6 @@ if [[ "$commit_hash" != "$existing_version" ]]; then
   printf "\033[33mThere's an updated version of macOSa available, run $update_command to update\033[0m\n"
 fi
 
-exit
-
 if $update_macosa; then
   printf "Updating MacOSa...\n"
   ./bin/macosa_download "update"

--- a/bin/macosa
+++ b/bin/macosa
@@ -14,7 +14,7 @@ Usage: `basename "$0"` [-h] [-u] [-l]
 
 Options:
   -h        Show this help
-  -u        Run a MacOS software update before provisioning
+  -u        Run a MacOS software update and macOSa update before provisioning
   -l        Logout when finished
   command:
     update  When this command is provided, MacOSa will be updated with the most recent 'master' version on github only
@@ -40,6 +40,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -u)
       update=true
+      update_macosa=true
       shift
       ;;
     -l)
@@ -52,6 +53,20 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [ -d .git ]; then
+  commit_hash=$(git rev-parse HEAD)
+  update_command="'git pull origin master' from ~/.macosa"
+else
+  commit_hash=$(curl -s https://api.github.com/repos/rockholla/macosa/branches/master | grep '"sha":' | head -1 | awk -F ':' '{print $2}' | awk -F '"' '{print $2}')
+  update_command="'macosa -u'"
+fi
+existing_version=$([ -f .version ] && cat .version)
+if [[ "$commit_hash" != "$existing_version" ]]; then
+  printf "\033[33mThere's an updated version of macOSa available, run $update_command to update\033[0m\n"
+fi
+
+exit
 
 if $update_macosa; then
   printf "Updating MacOSa...\n"

--- a/bin/macosa_download
+++ b/bin/macosa_download
@@ -16,6 +16,8 @@ curl -L -o macosa.zip https://github.com/rockholla/macosa/zipball/$branch/
 unzip macosa.zip &>/dev/null
 mv rockholla-macosa* macosa
 rm -rf macosa/docs
+commit_hash=$(curl -s https://api.github.com/repos/rockholla/macosa/branches/$branch | grep '"sha":' | head -1 | awk -F ':' '{print $2}' | awk -F '"' '{print $2}')
+echo $commit_hash > macosa/.version
 rm macosa.zip
 if $update; then
   rsync -a --delete --exclude user --exclude .vaultpass --exclude .downloads ~/Downloads/macosa/ ~/.macosa/

--- a/bin/macosa_download
+++ b/bin/macosa_download
@@ -2,7 +2,9 @@
 
 update=false
 
-if [ "$1" == "update" ]; then
+branch="${1:-master}"
+
+if [ "$2" == "update" ]; then
   update=true
 fi
 
@@ -10,12 +12,12 @@ cd ~/Downloads
 printf "Downloading MacOSa source files...\n"
 rm -rf ~/Downloads/macosa* &>/dev/null
 rm -rf ~/Downloads/rockholla* &>/dev/null
-rm -rf ~/Downloads/master.zip &>/dev/null
-curl -L -o master.zip https://github.com/rockholla/macosa/zipball/master/
-unzip master.zip &>/dev/null
+rm -rf ~/Downloads/macosa.zip &>/dev/null
+curl -L -o macosa.zip https://github.com/rockholla/macosa/zipball/$branch/
+unzip macosa.zip &>/dev/null
 mv rockholla-macosa* macosa
 rm -rf macosa/docs
-rm master.zip
+rm macosa.zip
 if $update; then
   rsync -a --delete --exclude user --exclude .vaultpass --exclude .downloads ~/Downloads/macosa/ ~/.macosa/
   printf "MacOSa update complete\n"

--- a/bin/macosa_download
+++ b/bin/macosa_download
@@ -2,11 +2,10 @@
 
 update=false
 
-branch="${1:-master}"
-
-if [ "$2" == "update" ]; then
+if [[ "$1" == "update" ]]; then
   update=true
 fi
+branch="${2:-master}"
 
 cd ~/Downloads
 printf "Downloading MacOSa source files...\n"

--- a/bin/macosa_functions
+++ b/bin/macosa_functions
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function get_os_version() {
+  os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
+  echo $os_version
+}
+
+function get_version_part() {
+  version_parts=(${1//./ })
+  if [[ "$2" == "major" ]]; then
+    echo "${version_parts[0]:-0}"
+  elif [[ "$2" == "minor" ]]; then
+    echo "${version_parts[1]:-0}"
+  elif [[ "$2" == "patch" ]]; then
+    echo "${version_parts[2]:-0}"
+  fi
+}

--- a/bin/macosa_get_os_version
+++ b/bin/macosa_get_os_version
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
-os_version_parts=(${os_version//./ })
-export OS_MAJOR_VERSION="${os_version_parts[0]}"
-export OS_MINOR_VERSION="${os_version_parts[1]}"
-export OS_PATCH_VERSION="${os_version_parts[1]:-0}"

--- a/bin/macosa_get_os_version
+++ b/bin/macosa_get_os_version
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
+os_version_parts=(${os_version//./ })
+export OS_MAJOR_VERSION="${os_version_parts[0]}"
+export OS_MINOR_VERSION="${os_version_parts[1]}"
+export OS_PATCH_VERSION="${os_version_parts[1]:-0}"

--- a/bin/macosa_homebrew
+++ b/bin/macosa_homebrew
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+root_pass="$1"
+
 if ! command -v brew &>/dev/null; then
   printf "Installing Homebrew...\n"
-  yes '' | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  echo "$root_pass" | sudo -S /bin/bash -c 'yes "" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
 else
   printf "Homebrew is installed.\n"
 fi

--- a/bin/macosa_homebrew
+++ b/bin/macosa_homebrew
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 root_pass="$1"
+echo "$root_pass" | sudo -S -v
+while true; do sleep 60; sudo -n true; kill -0 "$$" || exit; done 2>/dev/null &
 
 if ! command -v brew &>/dev/null; then
   printf "Installing Homebrew...\n"
-  echo "$root_pass" | sudo -S -i -u $(whoami) /bin/bash -c 'yes "" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
+  yes "" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 else
   printf "Homebrew is installed.\n"
 fi

--- a/bin/macosa_homebrew
+++ b/bin/macosa_homebrew
@@ -4,7 +4,7 @@ root_pass="$1"
 
 if ! command -v brew &>/dev/null; then
   printf "Installing Homebrew...\n"
-  echo "$root_pass" | sudo -S /bin/bash -c 'yes "" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
+  echo "$root_pass" | sudo -S -i -u $(whoami) /bin/bash -c 'yes "" | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
 else
   printf "Homebrew is installed.\n"
 fi

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -110,11 +110,8 @@ elif [[ "$install_type" == "full" ]]; then
     printf "Automatically accepting the Xcode license\n"
     echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
 
-    # this is to make sure we call xcode-select --install and initialize tools appropriately for compatibility purposes
-    # I *think* it's only necessary for El Capitan right now
-    if (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
-      xcode_tools "until_prompt"
-    fi
+    # even though we just installed the full Xcode app, it seems this tools install is necessary for cli tools compatibility
+    xcode_tools "until_prompt"
 
     printf "\033[32mXcode is finished installing.\033[0m\n"
   else

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -5,6 +5,11 @@
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 downloads_directory="$( cd "$this_dir/../.downloads" && pwd )"
 install_type="${1:-tools}"
+source "$this_dir/macosa_functions"
+
+os_version=$(get_os_version)
+os_major_version=$(get_version_part "$os_version" "major")
+os_minor_version=$(get_version_part "$os_version" "minor")
 
 function xcode_tools() {
   wait_type="$1"
@@ -106,7 +111,7 @@ elif [[ "$install_type" == "full" ]]; then
 
     # this is to make sure we call xcode-select --install and initialize tools appropriately for compatibility purposes
     # I *think* it's only necessary for El Capitan right now
-    if (( "$OS_MAJOR_VERSION" <= "10" )) && (( "$OS_MINOR_VERSION" <= "11" )); then
+    if (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
       xcode_tools "until_prompt"
     fi
 

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -7,14 +7,31 @@ downloads_directory="$( cd "$this_dir/../.downloads" && pwd )"
 install_type="${1:-tools}"
 
 function xcode_tools() {
+  wait_type="$1"
   say "To continue, please click install in the following popup window"
   # Prompt user to install the XCode Command Line Tools
   xcode-select --install &>/dev/null
 
   # Wait until the XCode Command Line Tools are installed
-  until xcode-select --print-path &>/dev/null; do
-    sleep 5
-  done
+  if [[ "$wait_type" == "until_prompt" ]]; then
+    say "When the tools install process is finished, let us know"
+    done_installing_tools=false
+    until $done_installing_tools; do
+      read -rp $'\033[33mAre you finished with the Xcode tools install? [Y/n] \033[0m' response
+      case "$response" in
+        [yY][eE][sS]|[yY])
+          done_installing_tools=true
+          ;;
+        *)
+          done_installing_tools=false
+          ;;
+      esac
+    done
+  else
+    until xcode-select --print-path &>/dev/null; do
+      sleep 5
+    done
+  fi
 }
 
 if [[ $install_type == "tools" ]]; then
@@ -22,7 +39,7 @@ if [[ $install_type == "tools" ]]; then
   if ! xcode-select --print-path &>/dev/null; then
     printf "Installing Xcode tools...\n"
 
-    xcode_tools
+    xcode_tools "until_installed"
 
     printf "Xcode tools are finished installing.\n"
   else
@@ -88,7 +105,7 @@ elif [[ "$install_type" == "full" ]]; then
     echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
 
     # this is to make sure we call xcode-select --install and initialize tools appropriately for compatibility purposes
-    xcode_tools
+    xcode_tools "until_prompt"
 
     printf "\033[32mXcode is finished installing.\033[0m\n"
   else

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -102,7 +102,8 @@ elif [[ "$install_type" == "full" ]]; then
     fi
     printf "Installing extracted Xcode.app to Applications...\n"
     echo $(cat ~/.macosa/.vaultpass) | sudo -S rsync -a /tmp/Xcode.app/ /Applications/Xcode.app &
-    printf "The installation of all Xcode files might take a little while, don't mind what looks like a passord prompt below, it's not actually asking you for your password...\n"
+    sleep 2
+    printf "The installation of all Xcode files might take a little while, don't mind what looks like a passord prompt above, it's not actually asking you for your password...\n"
     wait
     rm "/tmp/$xcode_download_filename"
 

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -11,6 +11,8 @@ os_version=$(get_os_version)
 os_major_version=$(get_version_part "$os_version" "major")
 os_minor_version=$(get_version_part "$os_version" "minor")
 
+xcode_version=""
+
 function xcode_tools() {
   wait_type="$1"
   say "To continue, please click install in the following popup window"
@@ -107,11 +109,15 @@ elif [[ "$install_type" == "full" ]]; then
     wait
     rm "/tmp/$xcode_download_filename"
 
-    printf "Automatically accepting the Xcode license\n"
-    echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
-
-    # even though we just installed the full Xcode app, it seems this tools install is necessary for cli tools compatibility
-    xcode_tools "until_prompt"
+    xcode_major_version=$(get_version_part "$xcode_version" "major")
+    if (( "$xcode_major_version" >= 9 )); then
+      printf "Initializing Xcode and accepting the license\n"
+      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -runFirstLaunch 2>/dev/null
+    else
+      printf "Accepting the Xcode license and opening it for the first time to initialize\n"
+      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
+      open /Applications/Xcode.app
+    fi
 
     printf "\033[32mXcode is finished installing.\033[0m\n"
   else

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -105,7 +105,10 @@ elif [[ "$install_type" == "full" ]]; then
     echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
 
     # this is to make sure we call xcode-select --install and initialize tools appropriately for compatibility purposes
-    xcode_tools "until_prompt"
+    # I *think* it's only necessary for El Capitan right now
+    if (( "$OS_MAJOR_VERSION" <= "10" )) && (( "$OS_MINOR_VERSION" <= "11" )); then
+      xcode_tools "until_prompt"
+    fi
 
     printf "\033[32mXcode is finished installing.\033[0m\n"
   else

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -117,6 +117,8 @@ elif [[ "$install_type" == "full" ]]; then
       printf "Accepting the Xcode license and opening it for the first time to initialize\n"
       echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
       open /Applications/Xcode.app
+      say "Once Xcode has launched successfully, press any key to continue"
+      read -rsp $'Once Xcode has launched successfully, press any key to continue...\n' -n1 key
     fi
 
     printf "\033[32mXcode is finished installing.\033[0m\n"

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -110,15 +110,13 @@ elif [[ "$install_type" == "full" ]]; then
     rm "/tmp/$xcode_download_filename"
 
     xcode_major_version=$(get_version_part "$xcode_version" "major")
-    if (( "$xcode_major_version" >= 9 )); then
+    if (( "$xcode_major_version" >= "9" )); then
       printf "Initializing Xcode and accepting the license\n"
-      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -runFirstLaunch 2>/dev/null
+      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -runFirstLaunch
     else
       printf "Accepting the Xcode license and opening it for the first time to initialize\n"
-      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
-      open /Applications/Xcode.app
-      say "Once Xcode has launched successfully, press any key to continue"
-      read -rsp $'Once Xcode has launched successfully, press any key to continue...\n' -n1 key
+      echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept
+      xcode_tools "until_prompt"
     fi
 
     printf "\033[32mXcode is finished installing.\033[0m\n"

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -6,18 +6,23 @@ this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 downloads_directory="$( cd "$this_dir/../.downloads" && pwd )"
 install_type="${1:-tools}"
 
+function xcode_tools() {
+  say "To continue, please click install in the following popup window"
+  # Prompt user to install the XCode Command Line Tools
+  xcode-select --install &>/dev/null
+
+  # Wait until the XCode Command Line Tools are installed
+  until xcode-select --print-path &>/dev/null; do
+    sleep 5
+  done
+}
+
 if [[ $install_type == "tools" ]]; then
 
   if ! xcode-select --print-path &>/dev/null; then
     printf "Installing Xcode tools...\n"
-    say "To continue, please click install in the following popup window"
-    # Prompt user to install the XCode Command Line Tools
-    xcode-select --install &>/dev/null
 
-    # Wait until the XCode Command Line Tools are installed
-    until xcode-select --print-path &>/dev/null; do
-      sleep 5
-    done
+    xcode_tools
 
     printf "Xcode tools are finished installing.\n"
   else
@@ -81,6 +86,9 @@ elif [[ "$install_type" == "full" ]]; then
 
     printf "Automatically accepting the Xcode license\n"
     echo $(cat ~/.macosa/.vaultpass) | sudo -S xcodebuild -license accept 2>/dev/null
+
+    # this is to make sure we call xcode-select --install and initialize tools appropriately for compatibility purposes
+    xcode_tools
 
     printf "\033[32mXcode is finished installing.\033[0m\n"
   else

--- a/bin/macosa_xcode
+++ b/bin/macosa_xcode
@@ -103,7 +103,7 @@ elif [[ "$install_type" == "full" ]]; then
     printf "Installing extracted Xcode.app to Applications...\n"
     echo $(cat ~/.macosa/.vaultpass) | sudo -S rsync -a /tmp/Xcode.app/ /Applications/Xcode.app &
     sleep 2
-    printf "The installation of all Xcode files might take a little while, don't mind what looks like a passord prompt above, it's not actually asking you for your password...\n"
+    printf " the installation of all Xcode files might take a little while...\n"
     wait
     rm "/tmp/$xcode_download_filename"
 

--- a/bin/macosa_xcode_download
+++ b/bin/macosa_xcode_download
@@ -33,7 +33,11 @@ if (( $major_version < "$MINIMUM_MAJOR_VERSION" )); then
   printf "\033[31mError: only Xcode version $MINIMUM_MAJOR_VERSION and above can be downloaded using this utility\033[0m\n"
   exit 1
 fi
-if (( "$major_version" >= "8" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
+if (( "$major_version" == "8" )) && (( "$minor_version" >= "3" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
+  printf "\033[31mOSX/macOS < 10.12 is only compatible with Xcode version 8.2.1 and below\033[0m\n"
+  exit 1
+fi
+if (( "$major_version" > "8" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
   printf "\033[31mOSX/macOS < 10.12 is only compatible with Xcode version 8.2.1 and below\033[0m\n"
   exit 1
 fi

--- a/bin/macosa_xcode_download
+++ b/bin/macosa_xcode_download
@@ -6,6 +6,7 @@ MINIMUM_MAJOR_VERSION="8"
 
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 current_directory=$(pwd)
+source "$this_dir/macosa_functions"
 
 mkdir -p "$this_dir/.tmp"
 
@@ -20,16 +21,19 @@ if [ -z "$apple_id" ] || [ -z "$apple_id_password" ] || [ -z "$xcode_version" ] 
   exit 1
 fi
 
-version_parts=(${xcode_version//./ })
-major_version="${version_parts[0]}"
-minor_version="${version_parts[1]:-0}"
-patch_version="${version_parts[2]:-0}"
+os_version=$(get_os_version)
+os_major_version=$(get_version_part "$os_version" "major")
+os_minor_version=$(get_version_part "$os_version" "minor")
+
+major_version=$(get_version_part "$xcode_version" "major")
+minor_version=$(get_version_part "$xcode_version" "minor")
+patch_version=$(get_version_part "$xcode_version" "patch")
 
 if (( $major_version < "$MINIMUM_MAJOR_VERSION" )); then
   printf "\033[31mError: only Xcode version $MINIMUM_MAJOR_VERSION and above can be downloaded using this utility\033[0m\n"
   exit 1
 fi
-if (( "$major_version" == "8" )) && (( "$minor_version" >= "3" )) && (( "$OS_MAJOR_VERSION" <= "10" )) && (( "$OS_MINOR_VERSION" <= "11" )); then
+if (( "$major_version" == "8" )) && (( "$minor_version" >= "3" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
   printf "\033[31mOSX/macOS < 10.12 is only compatible with Xcode version 8.2.1 and below\033[0m\n"
   exit 1
 fi

--- a/bin/macosa_xcode_download
+++ b/bin/macosa_xcode_download
@@ -3,6 +3,7 @@
 set -e
 
 MINIMUM_MAJOR_VERSION="8"
+
 this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 current_directory=$(pwd)
 
@@ -24,16 +25,11 @@ major_version="${version_parts[0]}"
 minor_version="${version_parts[1]:-0}"
 patch_version="${version_parts[2]:-0}"
 
-os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
-os_version_parts=(${os_version//./ })
-os_major_version="${os_version_parts[0]}"
-os_minor_version="${os_version_parts[1]}"
-
 if (( $major_version < "$MINIMUM_MAJOR_VERSION" )); then
   printf "\033[31mError: only Xcode version $MINIMUM_MAJOR_VERSION and above can be downloaded using this utility\033[0m\n"
   exit 1
 fi
-if (( "$major_version" == "8" )) && (( "$minor_version" >= "3" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
+if (( "$major_version" == "8" )) && (( "$minor_version" >= "3" )) && (( "$OS_MAJOR_VERSION" <= "10" )) && (( "$OS_MINOR_VERSION" <= "11" )); then
   printf "\033[31mOSX/macOS < 10.12 is only compatible with Xcode version 8.2.1 and below\033[0m\n"
   exit 1
 fi

--- a/bin/macosa_xcode_download
+++ b/bin/macosa_xcode_download
@@ -24,8 +24,17 @@ major_version="${version_parts[0]}"
 minor_version="${version_parts[1]:-0}"
 patch_version="${version_parts[2]:-0}"
 
+os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
+os_version_parts=(${os_version//./ })
+os_major_version="${version_parts[0]}"
+os_minor_version="${version_parts[1]}"
+
 if (( $major_version < "$MINIMUM_MAJOR_VERSION" )); then
   printf "\033[31mError: only Xcode version $MINIMUM_MAJOR_VERSION and above can be downloaded using this utility\033[0m\n"
+  exit 1
+fi
+if (( "$major_version" >= "8" )) && (( "$os_major_version" <= "10" )) && (( "$os_minor_version" <= "11" )); then
+  printf "\033[31mOSX/macOS < 10.12 is only compatible with Xcode version 8.2.1 and below\033[0m\n"
   exit 1
 fi
 if [[ $xcode_version == "8.3.3" || $xcode_version == "8.3.2" ]]; then
@@ -37,7 +46,6 @@ download_directory="Xcode_${xcode_version}"
 download_uri="https://developer.apple.com/services-account/download?path=/Developer_Tools/${download_directory}/${download_file_name}"
 
 initial_uri="https://developer.apple.com/download/"
-os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
 user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X ${os_version}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36"
 
 authenticate_uri="https://idmsa.apple.com/IDMSWebAuth/authenticate"

--- a/bin/macosa_xcode_download
+++ b/bin/macosa_xcode_download
@@ -26,8 +26,8 @@ patch_version="${version_parts[2]:-0}"
 
 os_version=$(sw_vers | grep ^ProductVersion | awk '{print $2}')
 os_version_parts=(${os_version//./ })
-os_major_version="${version_parts[0]}"
-os_minor_version="${version_parts[1]}"
+os_major_version="${os_version_parts[0]}"
+os_minor_version="${os_version_parts[1]}"
 
 if (( $major_version < "$MINIMUM_MAJOR_VERSION" )); then
   printf "\033[31mError: only Xcode version $MINIMUM_MAJOR_VERSION and above can be downloaded using this utility\033[0m\n"

--- a/install
+++ b/install
@@ -131,8 +131,12 @@ fi
 
 # Let's run a system software update first before installing
 ./bin/macosa_softwareupdate "$install_source/install $rebootargs"
-# make sure xcode and/or xcode tools are installed
-./bin/macosa_xcode $xcode
+# we have to install tools first no matter what for compatibility purposes
+./bin/macosa_xcode "tools"
+# make sure full xcode tools are installed
+if [[ "$xcode" == "full" ]]; then
+  ./bin/macosa_xcode $xcode
+fi
 # make sure homebrew is installed
 ./bin/macosa_homebrew
 

--- a/install
+++ b/install
@@ -103,6 +103,8 @@ fi
 
 cd ~/.macosa
 
+./bin/macosa_get_os_version
+
 # copy launchd on-reboot item into place
 if [ ! -f ~/Library/LaunchAgents/com.macosa.onboot.plist ]; then
   mkdir -p ~/Library/LaunchAgents

--- a/install
+++ b/install
@@ -140,12 +140,12 @@ fi
 ./bin/macosa_softwareupdate "$install_source/install $rebootargs"
 # we have to install tools first no matter what for compatibility purposes
 ./bin/macosa_xcode "tools"
+# make sure homebrew is installed
+./bin/macosa_homebrew
 # make sure full xcode tools are installed
 if [[ "$xcode" == "full" ]]; then
   ./bin/macosa_xcode "full"
 fi
-# make sure homebrew is installed
-./bin/macosa_homebrew
 
 if [ ! -d ~/.macosa/user ]; then
   say "Time to initialize your area for customizing My Mac O S A"

--- a/install
+++ b/install
@@ -141,7 +141,7 @@ fi
 # make sure either xcode tools or full xcode is installed
 ./bin/macosa_xcode "$xcode"
 # make sure homebrew is installed
-./bin/macosa_homebrew
+echo $(cat ~/.macosa/.vaultpass) | sudo -S ./bin/macosa_homebrew
 
 if [ ! -d ~/.macosa/user ]; then
   say "Time to initialize your area for customizing My Mac O S A"

--- a/install
+++ b/install
@@ -141,7 +141,7 @@ fi
 # make sure either xcode tools or full xcode is installed
 ./bin/macosa_xcode "$xcode"
 # make sure homebrew is installed
-echo $(cat ~/.macosa/.vaultpass) | sudo -u $(whoami) -S ./bin/macosa_homebrew
+./bin/macosa_homebrew "$root_pass"
 
 if [ ! -d ~/.macosa/user ]; then
   say "Time to initialize your area for customizing My Mac O S A"

--- a/install
+++ b/install
@@ -103,8 +103,6 @@ fi
 
 cd ~/.macosa
 
-./bin/macosa_get_os_version
-
 # copy launchd on-reboot item into place
 if [ ! -f ~/Library/LaunchAgents/com.macosa.onboot.plist ]; then
   mkdir -p ~/Library/LaunchAgents

--- a/install
+++ b/install
@@ -138,14 +138,14 @@ fi
 
 # Let's run a system software update first before installing
 ./bin/macosa_softwareupdate "$install_source/install $rebootargs"
-# we have to install tools first no matter what for compatibility purposes
-./bin/macosa_xcode "tools"
-# make sure homebrew is installed
-./bin/macosa_homebrew
 # make sure full xcode tools are installed
 if [[ "$xcode" == "full" ]]; then
   ./bin/macosa_xcode "full"
 fi
+# Ensure that tools are installed as well, in certain cases we need to explicitly run 'xcode-select --install' even after installing full xcode
+./bin/macosa_xcode "tools"
+# make sure homebrew is installed
+./bin/macosa_homebrew
 
 if [ ! -d ~/.macosa/user ]; then
   say "Time to initialize your area for customizing My Mac O S A"

--- a/install
+++ b/install
@@ -2,6 +2,7 @@
 
 passthru=""
 xcode="tools"
+branch="master"
 remote=false
 root_pass=""
 root_pass_confirm=""
@@ -17,6 +18,7 @@ Options:
   -f                    Force a fresh install
   -r                    If present, this is a remote install and the repo should be downloaded locally first
   -h                    Show this help
+  -b                    Install from branch, useful for installing from testing branches other than master
   -x [tools|full]       "full" will attempt to install the full Xcode app/suite, you'll be able to input the version you want during the install process. If "tools" only XCode cli tools will be installed (default = "tools")
 
 EOF
@@ -37,6 +39,10 @@ while [[ $# -gt 0 ]]; do
       usage
       shift
       ;;
+    -b)
+      branch="$2"
+      shift 2
+      ;;
     -x)
       xcode="$2"
       shift 2
@@ -51,7 +57,7 @@ done
 if $remote; then
   cd ~/Downloads
   if [ ! -d macosa ] || [ $fresh == true ]; then
-    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/master/bin/macosa_download) "install"
+    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) "install"
   fi
   install_source="$(pwd)/macosa"
 else

--- a/install
+++ b/install
@@ -135,7 +135,7 @@ fi
 ./bin/macosa_xcode "tools"
 # make sure full xcode tools are installed
 if [[ "$xcode" == "full" ]]; then
-  ./bin/macosa_xcode $xcode
+  ./bin/macosa_xcode "full"
 fi
 # make sure homebrew is installed
 ./bin/macosa_homebrew

--- a/install
+++ b/install
@@ -57,7 +57,7 @@ done
 if $remote; then
   cd ~/Downloads
   if [ ! -d macosa ] || [ $fresh == true ]; then
-    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) "install"
+    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) "install" "$branch"
   fi
   install_source="$(pwd)/macosa"
 else

--- a/install
+++ b/install
@@ -138,12 +138,8 @@ fi
 
 # Let's run a system software update first before installing
 ./bin/macosa_softwareupdate "$install_source/install $rebootargs"
-# make sure full xcode tools are installed
-if [[ "$xcode" == "full" ]]; then
-  ./bin/macosa_xcode "full"
-fi
-# Ensure that tools are installed as well, in certain cases we need to explicitly run 'xcode-select --install' even after installing full xcode
-./bin/macosa_xcode "tools"
+# make sure either xcode tools or full xcode is installed
+./bin/macosa_xcode "$xcode"
 # make sure homebrew is installed
 ./bin/macosa_homebrew
 

--- a/install
+++ b/install
@@ -141,7 +141,7 @@ fi
 # make sure either xcode tools or full xcode is installed
 ./bin/macosa_xcode "$xcode"
 # make sure homebrew is installed
-echo $(cat ~/.macosa/.vaultpass) | sudo -S ./bin/macosa_homebrew
+echo $(cat ~/.macosa/.vaultpass) | sudo -u $(whoami) -S ./bin/macosa_homebrew
 
 if [ ! -d ~/.macosa/user ]; then
   say "Time to initialize your area for customizing My Mac O S A"

--- a/install
+++ b/install
@@ -58,7 +58,7 @@ if $remote; then
   cd ~/Downloads
   if [ ! -d macosa ] || [ $fresh == true ]; then
     printf "Downloading source from macOSa branch $branch"
-    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) install $branch
+    bash <(curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) install $branch
   fi
   install_source="$(pwd)/macosa"
 else

--- a/install
+++ b/install
@@ -57,7 +57,8 @@ done
 if $remote; then
   cd ~/Downloads
   if [ ! -d macosa ] || [ $fresh == true ]; then
-    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) "install" "$branch"
+    printf "Downloading source from macOSa branch $branch"
+    bash <(curl https://raw.githubusercontent.com/rockholla/macosa/$branch/bin/macosa_download) install $branch
   fi
   install_source="$(pwd)/macosa"
 else

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -27,7 +27,9 @@
   changed_when: false
 
 - name: Install configured cask applications.
-  command: >
-    brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}
+  shell: >
+    echo $(cat {{ playbook_dir }}/.vaultpass) | sudo -S brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}
   with_items: "{{ homebrew_cask_apps }}"
   when: "item not in cask_installed_apps.stdout"
+  args:
+    warn: no

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -21,10 +21,12 @@
   when: homebrew_upgrade
 
 - name: Get list of apps installed with cask.
-  command: >
-    brew cask list
+  shell: >
+    echo $(cat {{ playbook_dir }}/.vaultpass) | sudo -S brew cask list
   register: cask_installed_apps
   changed_when: false
+  args:
+    warn: no
 
 - name: Install configured cask applications.
   shell: >

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -20,9 +20,14 @@
   homebrew: upgrade_all=yes
   when: homebrew_upgrade
 
+- name: "Refresh sudo cache"
+  command: "echo none"
+  become: yes
+  changed_when: false
+
 - name: Get list of apps installed with cask.
   shell: >
-    echo $(cat {{ playbook_dir }}/.vaultpass) | sudo -S brew cask list
+    brew cask list
   register: cask_installed_apps
   changed_when: false
   args:
@@ -30,7 +35,7 @@
 
 - name: Install configured cask applications.
   shell: >
-    echo $(cat {{ playbook_dir }}/.vaultpass) | sudo -S brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}
+    brew cask install {{ item }} --appdir={{ homebrew_cask_appdir }}
   with_items: "{{ homebrew_cask_apps }}"
   when: "item not in cask_installed_apps.stdout"
   args:

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -57,6 +57,7 @@
     content: "{{ ssh['config'] }}"
     dest: "/Users/{{ ansible_user_id }}/.ssh/config"
     mode: 0600
+  tags: [ ssh ]
 
 - name: Write ssh private key files
   copy:
@@ -64,6 +65,7 @@
     dest: "/Users/{{ ansible_user_id }}/.ssh/{{ item.name }}"
     mode: 0600
   with_items: "{{ ssh['keys'] }}"
+  tags: [ ssh ]
 
 - name: Write ssh public key files
   copy:
@@ -72,3 +74,4 @@
     mode: 0644
   when: item.public is defined
   with_items: "{{ ssh['keys'] }}"
+  tags: [ ssh ]


### PR DESCRIPTION
* add awareness for new version of macOSa available, and tie in `-u` argument to update macOSa
* updates to have brew in playbook/tasks use `ansible_become_pass`
* prevent homebrew install prompting for password
* deal w/ various Xcode full install flow issues
* add ability to kick off install from a branch other than master, useful for testing and maybe other things